### PR TITLE
Add ktlint auto-format PostToolUse hook

### DIFF
--- a/.claude/scripts/ktlint-format-on-save.sh
+++ b/.claude/scripts/ktlint-format-on-save.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FILE_PATH=$(python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(data.get('tool_input', {}).get('file_path', ''))
+" <<< "${CLAUDE_TOOL_INPUT:-{}}")
+
+[[ "$FILE_PATH" == *.kt ]] || exit 0
+
+GRADLE_FILE="$(dirname "$0")/../../build.gradle.kts"
+grep -q "jlleitschuh.gradle.ktlint" "$GRADLE_FILE" 2>/dev/null || exit 0
+
+echo "[ktlint-format] formatting $FILE_PATH"
+cd "$(dirname "$0")/../.." && ./gradlew ktlintFormat -q 2>&1 | tail -3


### PR DESCRIPTION
## Summary
- Adds `.claude/scripts/ktlint-format-on-save.sh` which auto-runs `./gradlew ktlintFormat` after every `.kt` file edit
- The hook is no-op safe: skips non-Kotlin files and skips if ktlint plugin is absent from `build.gradle.kts`
- Registered as the **first** PostToolUse hook so formatting runs before detekt — fixing style before analysis, not after

## Test plan
- [x] `./gradlew ktlintCheck` passes on this branch
- [ ] Edit any `.kt` file → hook prints `[ktlint-format] formatting <path>` and file is reformatted before detekt runs
- [ ] Edit a non-`.kt` file → hook exits silently (no output, exit 0)

🤖 Generated with Claude Code

## Summary by Sourcery

Chores:
- Add a ktlint format-on-save shell script that conditionally runs ./gradlew ktlintFormat for edited .kt files when the ktlint plugin is configured.