### PR TITLE
enhancement: build setup — centralize versions, AssertK + RestAssured, Log4j2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,16 +1,24 @@
 plugins {
-    kotlin("jvm") version "2.2.21"
-    kotlin("plugin.spring") version "2.2.21"
-    id("org.springframework.boot") version "4.0.3"
-    id("io.spring.dependency-management") version "1.1.7"
-    id("org.jlleitschuh.gradle.ktlint") version "12.2.0"
-    id("dev.detekt") version "2.0.0-alpha.1"
+    kotlin("jvm")
+    kotlin("plugin.spring")
+    id("org.springframework.boot")
+    id("io.spring.dependency-management")
+    id("org.jlleitschuh.gradle.ktlint")
+    id("dev.detekt")
     id("jacoco")
 }
 
 group = "com.iol"
 version = "0.0.1-SNAPSHOT"
 description = "sd-implementation-challenge"
+
+val springCloudVersion: String by project
+val springDocVersion: String by project
+val assertkVersion: String by project
+val restAssuredVersion: String by project
+val springmockkVersion: String by project
+val jacocoToolVersion: String by project
+val ktlintVersion: String by project
 
 java {
     toolchain {
@@ -22,19 +30,25 @@ configurations {
     compileOnly {
         extendsFrom(configurations.annotationProcessor.get())
     }
+    // spring-boot-starter-logging (Logback) conflicts with our Log4j2 setup:
+    //   - log4j-to-slf4j (from starter-logging) routes Log4j2 API → SLF4J
+    //   - log4j-slf4j2-impl (from starter-log4j2) routes SLF4J → Log4j2
+    // Both on classpath creates a cycle. Exclude the entire logging starter + its artifacts.
+    all {
+        exclude(group = "org.springframework.boot", module = "spring-boot-starter-logging")
+        exclude(group = "ch.qos.logback")
+        exclude(group = "org.apache.logging.log4j", module = "log4j-to-slf4j")
+    }
 }
 
 repositories {
     mavenCentral()
 }
 
-extra["springCloudVersion"] = "2025.1.0"
-
-val springDocVersion: String by project
-
 dependencies {
     implementation("org.springframework.boot:spring-boot-micrometer-tracing-brave")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-starter-log4j2")
     implementation("org.springframework.boot:spring-boot-starter-opentelemetry")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
@@ -53,13 +67,15 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test")
-    testImplementation("com.ninja-squad:springmockk:4.0.2")
+    testImplementation("com.ninja-squad:springmockk:$springmockkVersion")
+    testImplementation("com.willowtreeapps.assertk:assertk:$assertkVersion")
+    testImplementation("io.rest-assured:spring-web-test-client:$restAssuredVersion")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.cloud:spring-cloud-dependencies:${property("springCloudVersion")}")
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:$springCloudVersion")
     }
 }
 
@@ -82,7 +98,7 @@ configurations.matching { it.name.startsWith("detekt") }.all {
 
 ktlint {
     // ktlint 1.5+ uses the updated Kotlin AST API compatible with Kotlin 2.2.x (EXPECT_KEYWORD replaces HEADER_KEYWORD)
-    version = "1.5.0"
+    version = ktlintVersion
 }
 
 detekt {
@@ -92,7 +108,7 @@ detekt {
 
 jacoco {
     // 0.8.13 adds Java 24 (class file version 68) support
-    toolVersion = "0.8.13"
+    toolVersion = jacocoToolVersion
 }
 
 tasks.test {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,15 @@
+# Plugin versions
+kotlinVersion=2.2.21
+springBootVersion=4.0.3
+springDependencyManagementVersion=1.1.7
+ktlintPluginVersion=12.2.0
+detektPluginVersion=2.0.0-alpha.1
+
+# Dependency versions
 springDocVersion=3.0.1
+springCloudVersion=2025.1.0
+assertkVersion=0.28.1
+restAssuredVersion=5.5.0
+springmockkVersion=4.0.2
+jacocoToolVersion=0.8.13
+ktlintVersion=1.5.0

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,17 @@
+pluginManagement {
+    val kotlinVersion: String by settings
+    val springBootVersion: String by settings
+    val springDependencyManagementVersion: String by settings
+    val ktlintPluginVersion: String by settings
+    val detektPluginVersion: String by settings
+    plugins {
+        kotlin("jvm") version kotlinVersion
+        kotlin("plugin.spring") version kotlinVersion
+        id("org.springframework.boot") version springBootVersion
+        id("io.spring.dependency-management") version springDependencyManagementVersion
+        id("org.jlleitschuh.gradle.ktlint") version ktlintPluginVersion
+        id("dev.detekt") version detektPluginVersion
+        id("jacoco")
+    }
+}
 rootProject.name = "sd-implementation-challenge"

--- a/src/main/resources/log4j2-spring.xml
+++ b/src/main/resources/log4j2-spring.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} traceId=%X{traceId} spanId=%X{spanId} - %msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="Console"/>
+        </Root>
+        <Logger name="com.iol" level="DEBUG" additivity="false">
+            <AppenderRef ref="Console"/>
+        </Logger>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
## Summary
- Move all plugin/dependency versions to `gradle.properties`; `pluginManagement` in `settings.gradle.kts` resolves them via `by settings` delegation — zero inline version strings in `build.gradle.kts`
- Add **AssertK** (Kotlin-native fluent assertions) and **RestAssured WebTestClient** for Increments 2–6
- Replace **Logback** with **Log4j2**; exclude `spring-boot-starter-logging`, `ch.qos.logback`, and `log4j-to-slf4j` from all configurations to prevent the circular SLF4J bridge conflict; add `log4j2-spring.xml` with `traceId`/`spanId` MDC pattern (populated by Brave on every request)

## Test plan
- [x] `./gradlew build` passes — all existing tests green, ktlint + detekt + JaCoCo satisfied
- [x] No `log4j-to-slf4j` + `log4j-slf4j2-impl` conflict on classpath
- [ ] `./gradlew bootRun` → logs show `traceId=<hex>` pattern per request

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Centralize Gradle plugin and dependency version management, adopt Log4j2-based logging, and extend the test stack with additional assertion and WebTestClient libraries.

New Features:
- Introduce AssertK and RestAssured Spring WebTestClient for richer test assertions and HTTP testing.
- Add a Log4j2 logging configuration file with MDC-based trace and span ID output.

Enhancements:
- Centralize plugin and dependency versions in gradle.properties and resolve plugin versions via settings.gradle.kts pluginManagement.
- Switch the application logging starter from Spring Boot’s default logging to the Log4j2 starter and globally exclude conflicting logging artifacts.
- Configure ktlint and JaCoCo to use centrally managed tool versions via Gradle properties.