### PR TITLE
feature: domain types and ports — Increment 2

### DIFF
--- a/src/main/kotlin/com/iol/ratelimiter/core/domain/BucketState.kt
+++ b/src/main/kotlin/com/iol/ratelimiter/core/domain/BucketState.kt
@@ -1,0 +1,9 @@
+package com.iol.ratelimiter.core.domain
+
+// milliTokens (Long, not Double) enables exact integer CAS — 1 token = 1_000 milliTokens.
+// IEEE 754 Doubles can produce non-identical bit patterns for logically equal values;
+// integer CAS is always exact.
+data class BucketState(
+    val milliTokens: Long,
+    val lastRefillAt: Long,
+)

--- a/src/main/kotlin/com/iol/ratelimiter/core/domain/RateLimitKey.kt
+++ b/src/main/kotlin/com/iol/ratelimiter/core/domain/RateLimitKey.kt
@@ -1,0 +1,6 @@
+package com.iol.ratelimiter.core.domain
+
+@JvmInline
+value class RateLimitKey(
+    val value: String,
+)

--- a/src/main/kotlin/com/iol/ratelimiter/core/domain/RateLimitResult.kt
+++ b/src/main/kotlin/com/iol/ratelimiter/core/domain/RateLimitResult.kt
@@ -1,0 +1,9 @@
+package com.iol.ratelimiter.core.domain
+
+sealed class RateLimitResult {
+    data object Allowed : RateLimitResult()
+
+    data class Denied(
+        val retryAfterSeconds: Long,
+    ) : RateLimitResult()
+}

--- a/src/main/kotlin/com/iol/ratelimiter/core/domain/TokenBucketConfig.kt
+++ b/src/main/kotlin/com/iol/ratelimiter/core/domain/TokenBucketConfig.kt
@@ -1,0 +1,6 @@
+package com.iol.ratelimiter.core.domain
+
+data class TokenBucketConfig(
+    val capacity: Long,
+    val refillRatePerSecond: Long,
+)

--- a/src/main/kotlin/com/iol/ratelimiter/core/port/BucketStore.kt
+++ b/src/main/kotlin/com/iol/ratelimiter/core/port/BucketStore.kt
@@ -1,0 +1,14 @@
+package com.iol.ratelimiter.core.port
+
+import com.iol.ratelimiter.core.domain.BucketState
+import com.iol.ratelimiter.core.domain.RateLimitKey
+import java.util.concurrent.atomic.AtomicReference
+
+interface BucketStore {
+    // Returns the same AtomicReference across concurrent calls for the same key —
+    // the CAS loop in TokenBucketRateLimiter requires a shared reference, not a copy.
+    fun getOrCreate(
+        key: RateLimitKey,
+        initial: () -> BucketState,
+    ): AtomicReference<BucketState>
+}

--- a/src/main/kotlin/com/iol/ratelimiter/core/port/Clock.kt
+++ b/src/main/kotlin/com/iol/ratelimiter/core/port/Clock.kt
@@ -1,0 +1,5 @@
+package com.iol.ratelimiter.core.port
+
+fun interface Clock {
+    fun nowMillis(): Long
+}

--- a/src/main/kotlin/com/iol/ratelimiter/core/port/RateLimiterPort.kt
+++ b/src/main/kotlin/com/iol/ratelimiter/core/port/RateLimiterPort.kt
@@ -1,0 +1,9 @@
+package com.iol.ratelimiter.core.port
+
+import com.iol.ratelimiter.core.domain.RateLimitKey
+import com.iol.ratelimiter.core.domain.RateLimitResult
+
+interface RateLimiterPort {
+    // Synchronous (not suspend) — the algorithm is pure CPU arithmetic, no I/O.
+    fun tryConsume(key: RateLimitKey): RateLimitResult
+}

--- a/src/test/kotlin/com/iol/ratelimiter/core/domain/RateLimitKeyTest.kt
+++ b/src/test/kotlin/com/iol/ratelimiter/core/domain/RateLimitKeyTest.kt
@@ -1,0 +1,29 @@
+package com.iol.ratelimiter.core.domain
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotEqualTo
+import org.junit.jupiter.api.Test
+
+class RateLimitKeyTest {
+    @Test
+    fun `same value produces equal keys`() {
+        assertThat(RateLimitKey("user-1")).isEqualTo(RateLimitKey("user-1"))
+    }
+
+    @Test
+    fun `different values produce non-equal keys`() {
+        assertThat(RateLimitKey("user-1")).isNotEqualTo(RateLimitKey("user-2"))
+    }
+
+    @Test
+    fun `value property exposes the underlying string`() {
+        assertThat(RateLimitKey("user-1").value).isEqualTo("user-1")
+    }
+
+    @Test
+    fun `equal keys hash the same — usable as map key`() {
+        val map = hashMapOf(RateLimitKey("user-1") to 42)
+        assertThat(map[RateLimitKey("user-1")]).isEqualTo(42)
+    }
+}

--- a/src/test/kotlin/com/iol/ratelimiter/core/domain/RateLimitResultTest.kt
+++ b/src/test/kotlin/com/iol/ratelimiter/core/domain/RateLimitResultTest.kt
@@ -1,0 +1,30 @@
+package com.iol.ratelimiter.core.domain
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isSameInstanceAs
+import org.junit.jupiter.api.Test
+
+class RateLimitResultTest {
+    @Test
+    fun `Allowed is a singleton`() {
+        assertThat(RateLimitResult.Allowed).isSameInstanceAs(RateLimitResult.Allowed)
+    }
+
+    @Test
+    fun `Denied exposes retryAfterSeconds`() {
+        assertThat(RateLimitResult.Denied(30L).retryAfterSeconds).isEqualTo(30L)
+    }
+
+    @Test
+    fun `when on sealed type is exhaustive without else`() {
+        // This test is a compile-time proof: if a branch were missing, this would not compile.
+        val result: RateLimitResult = RateLimitResult.Allowed
+        val label =
+            when (result) {
+                is RateLimitResult.Allowed -> "allowed"
+                is RateLimitResult.Denied -> "denied"
+            }
+        assertThat(label).isEqualTo("allowed")
+    }
+}


### PR DESCRIPTION
## Summary
- All domain value types and port interfaces in `core/` — zero Spring/Jakarta imports
- `RateLimitKey` as `@JvmInline value class` (zero allocation, compile-time distinct type)
- `BucketState` with `milliTokens Long` (exact integer CAS — no IEEE 754 precision issues)
- `RateLimitResult` sealed class (`Allowed` data object singleton, `Denied` with `retryAfterSeconds`)
- `TokenBucketConfig` (capacity + refillRatePerSecond)
- `Clock` as `fun interface` (SAM — stubs as lambdas in tests: `Clock { fixedTime }`)
- `BucketStore` returns `AtomicReference<BucketState>` (shared reference required by CAS loop)
- `RateLimiterPort.tryConsume` is synchronous (CPU-bound, no I/O)

## Test plan
- [x] `RateLimitKeyTest` — equality, hash, value property
- [x] `RateLimitResultTest` — Allowed singleton, Denied field, exhaustive `when`
- [x] `./gradlew build` green — ktlint + detekt + JaCoCo all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce core rate limiting domain model and ports for a token-bucket rate limiter.

New Features:
- Add RateLimitKey inline value type to represent distinct, strongly-typed rate limit keys.
- Define BucketState, RateLimitResult, and TokenBucketConfig domain types for token-bucket rate limiting.
- Introduce Clock functional interface to abstract time in the core domain.
- Add BucketStore and RateLimiterPort interfaces as core ports for token-bucket rate limiting.

Tests:
- Add RateLimitKey tests covering equality, hashing, and value exposure.
- Add RateLimitResult tests validating Allowed singleton behavior, Denied properties, and sealed exhaustiveness.