### PR TITLE
feature: Token Bucket algorithm — Increment 3

### DIFF
--- a/src/main/kotlin/com/iol/ratelimiter/infra/InMemoryBucketStore.kt
+++ b/src/main/kotlin/com/iol/ratelimiter/infra/InMemoryBucketStore.kt
@@ -1,0 +1,23 @@
+package com.iol.ratelimiter.infra
+
+import com.iol.ratelimiter.core.domain.BucketState
+import com.iol.ratelimiter.core.domain.RateLimitKey
+import com.iol.ratelimiter.core.port.BucketStore
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * In-memory [BucketStore] backed by a [ConcurrentHashMap].
+ *
+ * [computeIfAbsent] is atomic — only one thread initializes the entry for a new key.
+ * All subsequent callers receive the same [AtomicReference] instance, which is the
+ * shared state required by the CAS loop in [TokenBucketRateLimiter].
+ */
+class InMemoryBucketStore : BucketStore {
+    private val store = ConcurrentHashMap<RateLimitKey, AtomicReference<BucketState>>()
+
+    override fun getOrCreate(
+        key: RateLimitKey,
+        initial: () -> BucketState,
+    ): AtomicReference<BucketState> = store.computeIfAbsent(key) { AtomicReference(initial()) }
+}

--- a/src/main/kotlin/com/iol/ratelimiter/infra/SystemClock.kt
+++ b/src/main/kotlin/com/iol/ratelimiter/infra/SystemClock.kt
@@ -1,0 +1,7 @@
+package com.iol.ratelimiter.infra
+
+import com.iol.ratelimiter.core.port.Clock
+
+object SystemClock : Clock {
+    override fun nowMillis() = System.currentTimeMillis()
+}

--- a/src/main/kotlin/com/iol/ratelimiter/infra/TokenBucketRateLimiter.kt
+++ b/src/main/kotlin/com/iol/ratelimiter/infra/TokenBucketRateLimiter.kt
@@ -1,0 +1,69 @@
+package com.iol.ratelimiter.infra
+
+import com.iol.ratelimiter.core.domain.BucketState
+import com.iol.ratelimiter.core.domain.RateLimitKey
+import com.iol.ratelimiter.core.domain.RateLimitResult
+import com.iol.ratelimiter.core.domain.TokenBucketConfig
+import com.iol.ratelimiter.core.port.BucketStore
+import com.iol.ratelimiter.core.port.Clock
+import com.iol.ratelimiter.core.port.RateLimiterPort
+
+private const val ONE_MILLI_TOKEN = 1_000L
+private const val MS_PER_SECOND = 1_000L
+
+/**
+ * Token Bucket rate limiter with lazy refill and CAS-based thread safety.
+ *
+ * **Algorithm**
+ * Each bucket holds `milliTokens` (Long). One token = 1000 milliTokens, chosen so that
+ * sub-token refills can accumulate without floating-point arithmetic. Refill is computed
+ * on every [tryConsume] call from elapsed wall time — no background threads required.
+ *
+ * **Thread safety**
+ * The CAS loop in [tryConsume] retries if another thread concurrently modifies the bucket.
+ * This eliminates the TOCTOU race where two threads both read a non-zero balance,
+ * both decide "allowed", and both subtract — spending the same token twice.
+ *
+ * See [TokenBucketConcurrencyTest] for the race-condition regression test.
+ */
+class TokenBucketRateLimiter(
+    private val config: TokenBucketConfig,
+    private val store: BucketStore,
+    private val clock: Clock,
+) : RateLimiterPort {
+    override fun tryConsume(key: RateLimitKey): RateLimitResult {
+        val ref = store.getOrCreate(key) { initialState() }
+        while (true) {
+            val current = ref.get()
+            val refilled = computeRefill(current)
+            if (refilled.milliTokens < ONE_MILLI_TOKEN) return RateLimitResult.Denied(retryAfterSeconds(refilled))
+            val next = refilled.copy(milliTokens = refilled.milliTokens - ONE_MILLI_TOKEN)
+            // CAS: if state changed between read and write, retry with fresh read
+            if (ref.compareAndSet(current, next)) return RateLimitResult.Allowed
+        }
+    }
+
+    private fun initialState() =
+        BucketState(
+            milliTokens = config.capacity * ONE_MILLI_TOKEN,
+            lastRefillAt = clock.nowMillis(),
+        )
+
+    private fun computeRefill(state: BucketState): BucketState {
+        val elapsedMs = clock.nowMillis() - state.lastRefillAt
+        // refillRatePerSecond [tokens/sec] × elapsedMs [ms] = earned milliTokens
+        // (units: tokens/sec × ms = tokens·ms/sec = milliTokens, since 1000ms/sec × 1000mt/token cancel)
+        val earned = config.refillRatePerSecond * elapsedMs
+        val capped = minOf(state.milliTokens + earned, config.capacity * ONE_MILLI_TOKEN)
+        return state.copy(milliTokens = capped, lastRefillAt = clock.nowMillis())
+    }
+
+    private fun retryAfterSeconds(state: BucketState): Long {
+        val missingMilliTokens = ONE_MILLI_TOKEN - state.milliTokens
+        // Rate in milliTokens/ms = refillRatePerSecond (1 token/sec = 1 mt/ms).
+        // ms needed = ceil(missingMilliTokens / refillRatePerSecond).
+        // Seconds needed = ceil(msNeeded / 1000) — always ≥ 1 for integer rates ≥ 1.
+        val msNeeded = (missingMilliTokens + config.refillRatePerSecond - 1) / config.refillRatePerSecond
+        return (msNeeded + MS_PER_SECOND - 1L) / MS_PER_SECOND
+    }
+}

--- a/src/test/kotlin/com/iol/ratelimiter/core/TokenBucketRateLimiterTest.kt
+++ b/src/test/kotlin/com/iol/ratelimiter/core/TokenBucketRateLimiterTest.kt
@@ -1,0 +1,154 @@
+package com.iol.ratelimiter.core
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isGreaterThanOrEqualTo
+import assertk.assertions.isInstanceOf
+import com.iol.ratelimiter.core.domain.RateLimitKey
+import com.iol.ratelimiter.core.domain.RateLimitResult
+import com.iol.ratelimiter.core.domain.TokenBucketConfig
+import com.iol.ratelimiter.core.port.Clock
+import com.iol.ratelimiter.infra.InMemoryBucketStore
+import com.iol.ratelimiter.infra.TokenBucketRateLimiter
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+/**
+ * Unit tests for the Token Bucket algorithm implemented in [TokenBucketRateLimiter].
+ *
+ * Uses a controllable [Clock] stub so all timing is deterministic — no real-time dependencies.
+ * Capacity = 10 tokens, refill rate = 5 tokens/sec (1 token per 200 ms) unless overridden per test.
+ *
+ * Concurrency correctness is covered separately in [TokenBucketConcurrencyTest].
+ */
+@DisplayName("TokenBucketRateLimiter — algorithm correctness")
+class TokenBucketRateLimiterTest {
+    private var now = 0L
+    private val clock = Clock { now }
+    private val config = TokenBucketConfig(capacity = 10L, refillRatePerSecond = 5L)
+
+    private lateinit var limiter: TokenBucketRateLimiter
+
+    @BeforeEach
+    fun setUp() {
+        now = 0L
+        limiter = TokenBucketRateLimiter(config, InMemoryBucketStore(), clock)
+    }
+
+    @Test
+    @DisplayName("first request on a fresh bucket is allowed")
+    fun `first request allowed`() {
+        assertThat(limiter.tryConsume(RateLimitKey("u"))).isInstanceOf(RateLimitResult.Allowed::class)
+    }
+
+    @Test
+    @DisplayName("initial bucket is full — exactly capacity requests are allowed, the next is denied")
+    fun `exactly capacity requests allowed then denied`() {
+        val key = RateLimitKey("u")
+        repeat(10) {
+            assertThat(limiter.tryConsume(key)).isInstanceOf(RateLimitResult.Allowed::class)
+        }
+        assertThat(limiter.tryConsume(key)).isInstanceOf(RateLimitResult.Denied::class)
+    }
+
+    @Test
+    @DisplayName("Denied result carries a retryAfterSeconds value of at least 1")
+    fun `denied result has positive retryAfterSeconds`() {
+        val key = RateLimitKey("u")
+        repeat(10) { limiter.tryConsume(key) }
+        val result = limiter.tryConsume(key) as RateLimitResult.Denied
+        assertThat(result.retryAfterSeconds).isGreaterThanOrEqualTo(1L)
+    }
+
+    @Test
+    @DisplayName("after 200 ms (1 token refilled at 5/sec), a denied bucket becomes allowed again")
+    fun `refill after 200ms restores one token`() {
+        val key = RateLimitKey("u")
+        repeat(10) { limiter.tryConsume(key) }
+        now += 200L
+        assertThat(limiter.tryConsume(key)).isInstanceOf(RateLimitResult.Allowed::class)
+    }
+
+    /**
+     * Parameterized partial-refill scenarios.
+     *
+     * At 5 tokens/sec, each millisecond earns 5 milliTokens. One full token = 1000 milliTokens.
+     * After 100 ms → 500 milliTokens earned (< 1000) → still denied.
+     * After 200 ms → 1000 milliTokens earned → allowed.
+     */
+    @ParameterizedTest(name = "after {0} ms elapsed: result is {1}")
+    @CsvSource(
+        "100, denied",
+        "199, denied",
+        "200, allowed",
+    )
+    @DisplayName("sub-token partial refill: only a full 1000 milliTokens unlocks a request")
+    fun `partial refill does not allow a request`(
+        elapsedMs: Long,
+        expected: String,
+    ) {
+        val key = RateLimitKey("u")
+        repeat(10) { limiter.tryConsume(key) }
+        now += elapsedMs
+        val result = limiter.tryConsume(key)
+        if (expected == "allowed") {
+            assertThat(result).isInstanceOf(RateLimitResult.Allowed::class)
+        } else {
+            assertThat(result).isInstanceOf(RateLimitResult.Denied::class)
+        }
+    }
+
+    @Test
+    @DisplayName("refill is capped at capacity — no token overflow above bucket size")
+    fun `refill does not exceed capacity`() {
+        val key = RateLimitKey("u")
+        // Advance 10 seconds → would refill 50 tokens, but capacity is 10
+        now += 10_000L
+        repeat(10) {
+            assertThat(limiter.tryConsume(key)).isInstanceOf(RateLimitResult.Allowed::class)
+        }
+        assertThat(limiter.tryConsume(key)).isInstanceOf(RateLimitResult.Denied::class)
+    }
+
+    @Test
+    @DisplayName("frozen clock — no time passes, denied stays denied")
+    fun `frozen clock keeps bucket exhausted`() {
+        val key = RateLimitKey("u")
+        repeat(10) { limiter.tryConsume(key) }
+        repeat(5) {
+            assertThat(limiter.tryConsume(key)).isInstanceOf(RateLimitResult.Denied::class)
+        }
+    }
+
+    @Test
+    @DisplayName("two keys share no state — each has its own independent bucket")
+    fun `two keys are independent`() {
+        val a = RateLimitKey("a")
+        val b = RateLimitKey("b")
+        repeat(10) { limiter.tryConsume(a) }
+        assertThat(limiter.tryConsume(b)).isInstanceOf(RateLimitResult.Allowed::class)
+    }
+
+    @Test
+    @DisplayName("fresh bucket starts full — initial state equals capacity")
+    fun `initial bucket is full`() {
+        val key = RateLimitKey("fresh")
+        // A full bucket allows exactly capacity requests with zero time elapsed
+        repeat(10) {
+            assertThat(limiter.tryConsume(key)).isInstanceOf(RateLimitResult.Allowed::class)
+        }
+    }
+
+    @Test
+    @DisplayName("retryAfterSeconds is the ceiling of 1 token at the current refill rate")
+    fun `retryAfterSeconds is ceiling of refill period`() {
+        val key = RateLimitKey("u")
+        repeat(10) { limiter.tryConsume(key) }
+        val denied = limiter.tryConsume(key) as RateLimitResult.Denied
+        // At 5 tokens/sec, 1 token takes 200ms = 0.2 sec → ceiling = 1
+        assertThat(denied.retryAfterSeconds).isEqualTo(1L)
+    }
+}

--- a/src/test/kotlin/com/iol/ratelimiter/infra/InMemoryBucketStoreTest.kt
+++ b/src/test/kotlin/com/iol/ratelimiter/infra/InMemoryBucketStoreTest.kt
@@ -1,0 +1,62 @@
+package com.iol.ratelimiter.infra
+
+import assertk.assertThat
+import assertk.assertions.isFalse
+import assertk.assertions.isNotSameInstanceAs
+import assertk.assertions.isSameInstanceAs
+import assertk.assertions.isTrue
+import com.iol.ratelimiter.core.domain.BucketState
+import com.iol.ratelimiter.core.domain.RateLimitKey
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [InMemoryBucketStore].
+ *
+ * Verifies key isolation and the "create-once" contract: the same [AtomicReference] must be
+ * returned on every call for a given key so that concurrent CAS loops share state.
+ */
+@DisplayName("InMemoryBucketStore")
+class InMemoryBucketStoreTest {
+    private lateinit var store: InMemoryBucketStore
+
+    @BeforeEach
+    fun setUp() {
+        store = InMemoryBucketStore()
+    }
+
+    @Test
+    @DisplayName("first access calls the initializer")
+    fun `new key calls initial lambda`() {
+        var called = false
+        store.getOrCreate(RateLimitKey("k")) {
+            called = true
+            BucketState(1_000L, 0L)
+        }
+        assertThat(called).isTrue()
+    }
+
+    @Test
+    @DisplayName("second access returns the same AtomicReference without calling initializer again")
+    fun `existing key skips initial lambda and returns same reference`() {
+        val initial = BucketState(1_000L, 0L)
+        val first = store.getOrCreate(RateLimitKey("k")) { initial }
+        var secondCalled = false
+        val second =
+            store.getOrCreate(RateLimitKey("k")) {
+                secondCalled = true
+                initial
+            }
+        assertThat(secondCalled).isFalse()
+        assertThat(second).isSameInstanceAs(first)
+    }
+
+    @Test
+    @DisplayName("distinct keys produce independent AtomicReferences")
+    fun `two different keys yield distinct references`() {
+        val a = store.getOrCreate(RateLimitKey("a")) { BucketState(1_000L, 0L) }
+        val b = store.getOrCreate(RateLimitKey("b")) { BucketState(1_000L, 0L) }
+        assertThat(a).isNotSameInstanceAs(b)
+    }
+}


### PR DESCRIPTION
## Summary
- `SystemClock` — singleton `Clock` using `System.currentTimeMillis()`
- `InMemoryBucketStore` — `ConcurrentHashMap + computeIfAbsent` guarantees one `AtomicReference` per key across concurrent callers
- `TokenBucketRateLimiter` — lazy refill (computed on `tryConsume`), `milliTokens` Long arithmetic (no floating-point), CAS loop in `tryConsume`, `retryAfterSeconds` via ceiling division in ms then seconds

## Key algorithm details
- Refill: `earned = refillRatePerSecond × elapsedMs` (units cancel: tokens/sec × ms = milliTokens since 1 token = 1000 mt)
- Capped at `capacity × 1000` milliTokens — no token overflow
- `retryAfterSeconds`: ceiling of ms_needed/1000 — always ≥ 1 for integer rates ≥ 1

## Test plan
- [x] `InMemoryBucketStoreTest` — 3 cases: init called once, same reference returned, key isolation
- [x] `TokenBucketRateLimiterTest` — 10 cases + `@ParameterizedTest @CsvSource` for sub-token boundary (100ms/199ms/200ms); uses `@DisplayName` for readable test names
- [x] `./gradlew build` — all 23 tests green, ktlint + detekt + JaCoCo 80% satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement a token-bucket based rate limiter backed by an in-memory bucket store and pluggable clock.

New Features:
- Add TokenBucketRateLimiter implementing a milli-token based token bucket algorithm with lazy refill and retry-after support.
- Introduce an in-memory BucketStore implementation using ConcurrentHashMap for per-key bucket state.
- Provide a SystemClock implementation of the Clock interface using system time.

Tests:
- Add unit tests for InMemoryBucketStore covering single-initialization and key isolation guarantees.
- Add algorithm-focused unit tests for TokenBucketRateLimiter, including refill behavior, retry-after calculation, and multi-key independence.