### PR TITLE
feature: WebFlux functional web adapter — Increment 5

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{kt,kts}]
+max_line_length = 130

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,6 +104,7 @@ ktlint {
 detekt {
     buildUponDefaultConfig = true
     allRules = false
+    config.setFrom("detekt.yml")
 }
 
 jacoco {

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,0 +1,3 @@
+style:
+  MaxLineLength:
+    maxLineLength: 130

--- a/src/main/kotlin/com/iol/ratelimiter/RateLimiterConfig.kt
+++ b/src/main/kotlin/com/iol/ratelimiter/RateLimiterConfig.kt
@@ -1,0 +1,41 @@
+package com.iol.ratelimiter
+
+import com.iol.ratelimiter.adapter.api.RateLimitHandler
+import com.iol.ratelimiter.core.domain.TokenBucketConfig
+import com.iol.ratelimiter.core.port.RateLimiterPort
+import com.iol.ratelimiter.infra.InMemoryBucketStore
+import com.iol.ratelimiter.infra.SystemClock
+import com.iol.ratelimiter.infra.TokenBucketRateLimiter
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.validation.Validator
+import com.iol.ratelimiter.adapter.api.rateLimitRouter as buildRateLimitRouter
+
+/**
+ * Wires all rate-limiter beans. Single source of truth for the dependency graph —
+ * no `@Component` or `@Autowired` annotations exist in `infra/` or `adapter/`.
+ */
+@Configuration
+class RateLimiterConfig {
+    @Bean
+    fun tokenBucketConfig(
+        @Value("\${rate-limiter.capacity}") capacity: Long,
+        @Value("\${rate-limiter.refill-rate-per-second}") refillRatePerSecond: Long,
+    ) = TokenBucketConfig(capacity, refillRatePerSecond)
+
+    @Bean
+    fun bucketStore() = InMemoryBucketStore()
+
+    @Bean
+    fun rateLimiter(config: TokenBucketConfig): RateLimiterPort = TokenBucketRateLimiter(config, bucketStore(), SystemClock)
+
+    @Bean
+    fun rateLimitHandler(
+        rateLimiter: RateLimiterPort,
+        validator: Validator,
+    ) = RateLimitHandler(rateLimiter, validator)
+
+    @Bean
+    fun rateLimitRouter(handler: RateLimitHandler) = buildRateLimitRouter(handler)
+}

--- a/src/main/kotlin/com/iol/ratelimiter/adapter/api/RateLimitExceededException.kt
+++ b/src/main/kotlin/com/iol/ratelimiter/adapter/api/RateLimitExceededException.kt
@@ -1,0 +1,15 @@
+package com.iol.ratelimiter.adapter.api
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
+
+/**
+ * Thrown by [RateLimitHandler] when the rate limiter denies a request.
+ *
+ * Wraps [ResponseStatusException] (429 Too Many Requests) so Spring's exception handling
+ * infrastructure maps it to the correct HTTP response without any conditional logic in the handler.
+ * The [retryAfterSeconds] value is surfaced via the standard `Retry-After` header.
+ */
+class RateLimitExceededException(
+    val retryAfterSeconds: Long,
+) : ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS)

--- a/src/main/kotlin/com/iol/ratelimiter/adapter/api/RateLimitExceptionHandler.kt
+++ b/src/main/kotlin/com/iol/ratelimiter/adapter/api/RateLimitExceptionHandler.kt
@@ -1,0 +1,23 @@
+package com.iol.ratelimiter.adapter.api
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+/**
+ * Global exception handler for rate-limiter adapter exceptions.
+ *
+ * Maps [RateLimitExceededException] to a 429 response with `Retry-After` header and
+ * `{"allowed":false}` body. Keeping this mapping here (rather than in the handler) is
+ * what makes [RateLimitHandler] truly thin — the handler delegates, never decides the
+ * HTTP response for the denied case.
+ */
+@RestControllerAdvice
+class RateLimitExceptionHandler {
+    @ExceptionHandler(RateLimitExceededException::class)
+    fun handleRateLimitExceeded(ex: RateLimitExceededException): ResponseEntity<RateLimitResponse> =
+        ResponseEntity
+            .status(ex.statusCode)
+            .header("Retry-After", ex.retryAfterSeconds.toString())
+            .body(RateLimitResponse(false))
+}

--- a/src/main/kotlin/com/iol/ratelimiter/adapter/api/RateLimitHandler.kt
+++ b/src/main/kotlin/com/iol/ratelimiter/adapter/api/RateLimitHandler.kt
@@ -1,0 +1,36 @@
+package com.iol.ratelimiter.adapter.api
+
+import com.iol.ratelimiter.core.domain.RateLimitKey
+import com.iol.ratelimiter.core.domain.RateLimitResult
+import com.iol.ratelimiter.core.port.RateLimiterPort
+import org.springframework.validation.BeanPropertyBindingResult
+import org.springframework.validation.Validator
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.awaitBody
+import org.springframework.web.reactive.function.server.bodyValueAndAwait
+
+/**
+ * Thin WebFlux handler for the rate-limit check endpoint.
+ *
+ * Validates the request body, delegates to [RateLimiterPort], and returns 200 on success.
+ * On denial, throws [RateLimitExceededException] — the HTTP 429 mapping and `Retry-After`
+ * header are handled by [RateLimitExceptionHandler], keeping this class free of conditional
+ * response-building logic.
+ */
+class RateLimitHandler(
+    private val rateLimiter: RateLimiterPort,
+    private val validator: Validator,
+) {
+    suspend fun check(request: ServerRequest): ServerResponse {
+        val body = request.awaitBody<RateLimitRequest>()
+        val errors = BeanPropertyBindingResult(body, "rateLimitRequest")
+        validator.validate(body, errors)
+        if (errors.hasErrors()) return ServerResponse.badRequest().bodyValueAndAwait(errors.allErrors.map { it.defaultMessage })
+
+        return when (val result = rateLimiter.tryConsume(RateLimitKey(body.key))) {
+            is RateLimitResult.Allowed -> ServerResponse.ok().bodyValueAndAwait(RateLimitResponse(true))
+            is RateLimitResult.Denied -> throw RateLimitExceededException(result.retryAfterSeconds)
+        }
+    }
+}

--- a/src/main/kotlin/com/iol/ratelimiter/adapter/api/RateLimitRequest.kt
+++ b/src/main/kotlin/com/iol/ratelimiter/adapter/api/RateLimitRequest.kt
@@ -1,0 +1,7 @@
+package com.iol.ratelimiter.adapter.api
+
+import jakarta.validation.constraints.NotBlank
+
+data class RateLimitRequest(
+    @field:NotBlank val key: String,
+)

--- a/src/main/kotlin/com/iol/ratelimiter/adapter/api/RateLimitResponse.kt
+++ b/src/main/kotlin/com/iol/ratelimiter/adapter/api/RateLimitResponse.kt
@@ -1,0 +1,5 @@
+package com.iol.ratelimiter.adapter.api
+
+data class RateLimitResponse(
+    val allowed: Boolean,
+)

--- a/src/main/kotlin/com/iol/ratelimiter/adapter/api/RateLimiterRouter.kt
+++ b/src/main/kotlin/com/iol/ratelimiter/adapter/api/RateLimiterRouter.kt
@@ -1,0 +1,8 @@
+package com.iol.ratelimiter.adapter.api
+
+import org.springframework.web.reactive.function.server.coRouter
+
+fun rateLimitRouter(handler: RateLimitHandler) =
+    coRouter {
+        POST("/api/rate-limit/check", handler::check)
+    }

--- a/src/test/kotlin/com/iol/ratelimiter/adapter/api/RateLimitHandlerTest.kt
+++ b/src/test/kotlin/com/iol/ratelimiter/adapter/api/RateLimitHandlerTest.kt
@@ -1,0 +1,111 @@
+package com.iol.ratelimiter.adapter.api
+
+import com.iol.ratelimiter.core.domain.RateLimitKey
+import com.iol.ratelimiter.core.domain.RateLimitResult
+import com.iol.ratelimiter.core.port.RateLimiterPort
+import com.iol.sdimplementationchallenge.SdImplementationChallengeApplication
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.http.MediaType
+import org.springframework.test.web.reactive.server.WebTestClient
+
+/**
+ * Integration tests for the full HTTP layer: [RateLimitHandler] + [RateLimitExceptionHandler].
+ *
+ * Uses `@SpringBootTest(RANDOM_PORT)` so the exception handler advice (`@RestControllerAdvice`)
+ * and bean validation are both active. [RateLimiterPort] is mocked via `@MockkBean` to keep
+ * tests isolated from the algorithm implementation.
+ *
+ * Verifies:
+ * - 200 OK with `{"allowed":true}` on success
+ * - 429 with `Retry-After` header and `{"allowed":false}` on denial (via exception handler)
+ * - 400 on missing or blank key (bean validation)
+ */
+@SpringBootTest(
+    classes = [SdImplementationChallengeApplication::class],
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+)
+@DisplayName("RateLimitHandler — HTTP contract")
+class RateLimitHandlerTest {
+    @LocalServerPort
+    private var port: Int = 0
+
+    private lateinit var client: WebTestClient
+
+    @MockkBean
+    private lateinit var rateLimiter: RateLimiterPort
+
+    @BeforeEach
+    fun setUp() {
+        client = WebTestClient.bindToServer().baseUrl("http://localhost:$port").build()
+    }
+
+    @Test
+    @DisplayName("allowed result → 200 OK with allowed=true body")
+    fun `allowed result returns 200 with allowed body`() {
+        every { rateLimiter.tryConsume(RateLimitKey("user-1")) } returns RateLimitResult.Allowed
+
+        client
+            .post()
+            .uri("/api/rate-limit/check")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"key":"user-1"}""")
+            .exchange()
+            .expectStatus()
+            .isOk
+            .expectBody()
+            .jsonPath("$.allowed")
+            .isEqualTo(true)
+    }
+
+    @Test
+    @DisplayName("denied result → 429 with allowed=false body and Retry-After header")
+    fun `denied result returns 429 with Retry-After header and denied body`() {
+        every { rateLimiter.tryConsume(RateLimitKey("user-1")) } returns RateLimitResult.Denied(5L)
+
+        client
+            .post()
+            .uri("/api/rate-limit/check")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"key":"user-1"}""")
+            .exchange()
+            .expectStatus()
+            .isEqualTo(429)
+            .expectHeader()
+            .valueEquals("Retry-After", "5")
+            .expectBody()
+            .jsonPath("$.allowed")
+            .isEqualTo(false)
+    }
+
+    @Test
+    @DisplayName("missing key field → 400 Bad Request")
+    fun `missing key field returns 400`() {
+        client
+            .post()
+            .uri("/api/rate-limit/check")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{}""")
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+    }
+
+    @Test
+    @DisplayName("blank key value → 400 Bad Request")
+    fun `blank key value returns 400`() {
+        client
+            .post()
+            .uri("/api/rate-limit/check")
+            .contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("""{"key":""}""")
+            .exchange()
+            .expectStatus()
+            .isBadRequest
+    }
+}


### PR DESCRIPTION
## Summary
- **4-piece WebFlux functional pattern**: `RateLimitRequest` (DTO + `@NotBlank`), `RateLimitResponse`, `RateLimitHandler` (thin), `rateLimitRouter` (`coRouter`)
- **Exception-based thin handler**: handler throws `RateLimitExceededException` (extends `ResponseStatusException(429)`) on denial; `@RestControllerAdvice` owns the 429 + `Retry-After` header mapping — zero HTTP status decisions in the handler
- **Bean validation**: `Validator` injected into handler; `BeanPropertyBindingResult` validates `@field:NotBlank` before calling `tryConsume` → 400 on blank/missing key
- **`RateLimiterConfig`**: single `@Configuration` class wires all beans — zero `@Component`/`@Autowired` in `infra/` or `adapter/`
- **`.editorconfig` + `detekt.yml`**: align `max_line_length=130` across ktlint and detekt

## Why exception-based?
- Handler knows nothing about 429 or `Retry-After` — it throws on denial, advice maps it
- Demonstrates Spring exception handling as requested; `ResponseStatusException` subclass carries the domain value (`retryAfterSeconds`)
- Trade-off: exceptions-as-control-flow is debated; here justified because denial is a business-level signal, not a crash

## Test plan
- [x] `@SpringBootTest(RANDOM_PORT)` + `@MockkBean` — full HTTP layer (handler + exception handler + validation active)
- [x] 200 on allowed, 429 + `Retry-After` on denied, 400 on missing/blank key
- [x] `./gradlew build` — all 37 tests green, ktlint + detekt + JaCoCo satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a WebFlux functional HTTP adapter and configuration for the rate limiter, including validation, exception mapping, and router wiring.

New Features:
- Add WebFlux functional rate-limit endpoint with request/response DTOs and router for /api/rate-limit/check.
- Introduce exception-based handling for denied requests via a custom RateLimitExceededException and global advice that returns 429 with Retry-After.

Enhancements:
- Centralize rate-limiter bean wiring in a dedicated @Configuration class without component annotations in infra/adapter.
- Align static analysis configuration by adding a shared detekt.yml and referencing it from the Gradle detekt setup.

Build:
- Configure Detekt to load rules from detekt.yml for consistent linting.

Tests:
- Add Spring Boot WebFlux integration tests covering success (200), denial (429 + Retry-After), and validation failures (400) for the rate-limit endpoint.