### PR TITLE
enhancement: claude automations — new-handler skill, core boundary guard, spring-optimize, coverage-diff-guardian

### DIFF
--- a/.claude/agents/coverage-diff-guardian.md
+++ b/.claude/agents/coverage-diff-guardian.md
@@ -1,0 +1,94 @@
+# coverage-diff-guardian
+
+Parse the JaCoCo XML report and flag files with insufficient line coverage. Invoked after each increment or before opening a PR to catch silent coverage regressions.
+
+---
+
+## Coverage Thresholds
+
+| Level | Threshold | Action |
+|-------|-----------|--------|
+| Warning | < 90% line coverage | Report with `⚠` |
+| Error | < 80% line coverage | Report with `✗` and FAIL the check |
+
+The project's JaCoCo rule enforces 80% on `com/iol/ratelimiter/core/*` and `com/iol/ratelimiter/infra/*`. This agent surfaces per-file data that the aggregate rule hides.
+
+---
+
+## Steps
+
+### 1. Generate the report
+
+```bash
+./gradlew jacocoTestReport
+```
+
+Report written to: `build/reports/jacoco/test/jacocoTestReport.xml`
+
+### 2. Parse per-file coverage
+
+Parse `jacocoTestReport.xml`. For each `<sourcefile>` node, compute:
+
+```
+linesCovered   = sum of <line covered="..."> where covered > 0
+linesTotal     = count of all <line> elements
+coverageRatio  = linesCovered / linesTotal
+```
+
+Alternatively, read the `COUNTER type="LINE"` element on each `<sourcefile>`:
+- `missed` = lines not covered
+- `covered` = lines covered
+- `ratio = covered / (missed + covered)`
+
+### 3. Filter to guarded packages
+
+Only report on files under:
+- `com/iol/ratelimiter/core/`
+- `com/iol/ratelimiter/infra/`
+
+Ignore `adapter/api/` — covered by integration tests, excluded from the 80% rule.
+
+### 4. Output report
+
+```
+Coverage Report — build/reports/jacoco/test/jacocoTestReport.xml
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✓  core/domain/RateLimitKey.kt          100%  (8/8)
+✓  core/domain/BucketState.kt           100%  (4/4)
+✓  core/domain/RateLimitResult.kt        96%  (25/26)
+⚠  infra/TokenBucketRateLimiter.kt       85%  (34/40)  [below 90% warning]
+✗  infra/SomeNewFile.kt                  72%  (18/25)  [below 80% — FAIL]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Result: FAIL — 1 file(s) below 80% threshold
+```
+
+If all files ≥ 80%:
+```
+Result: PASS — all guarded files meet 80% minimum
+```
+
+### 5. Suggest fixes for failing files
+
+For each `✗` file, list the uncovered line numbers (from `<line mi="1">` in the XML). This helps pinpoint missing test cases without opening the report HTML.
+
+---
+
+## How to Invoke
+
+```
+Use the coverage-diff-guardian agent to check coverage after the last increment.
+```
+
+Or as part of the quality gate workflow:
+```bash
+./gradlew jacocoTestReport
+# then invoke coverage-diff-guardian
+```
+
+---
+
+## Relationship to JaCoCo Rule
+
+The JaCoCo `jacocoTestCoverageVerification` task in `build.gradle.kts` enforces 80% at the **package** level (aggregate). This agent works at the **file** level — it catches cases where one well-tested file masks a poorly-tested new file in the same package.

--- a/.claude/scripts/detekt-on-save.sh
+++ b/.claude/scripts/detekt-on-save.sh
@@ -20,5 +20,5 @@ fi
 cd "$PROJECT_DIR"
 
 echo "--- Detekt (on save) ---"
-# detektMain is faster than detekt (skips test sources)
-./gradlew detektMain --continue -q 2>&1 | tail -30
+# detekt covers both main and test source sets — catches violations in test code too
+./gradlew detekt --continue -q 2>&1 | tail -30

--- a/.claude/scripts/guard-core-boundaries.sh
+++ b/.claude/scripts/guard-core-boundaries.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Blocks Spring/Jakarta imports from being written into core/ or infra/ packages.
+# Runs as a PreToolUse hook before every Edit or Write on a Kotlin file.
+
+set -euo pipefail
+
+FILE=$(echo "${CLAUDE_TOOL_INPUT:-}" | python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('file_path', ''))" 2>/dev/null || echo "")
+
+# Only guard Kotlin files in core/ or infra/
+if ! echo "$FILE" | grep -qE "src/main/kotlin/com/iol/ratelimiter/(core|infra)/"; then
+  exit 0
+fi
+
+# Check the *incoming content* (new_string for Edit, content for Write)
+CONTENT=$(echo "${CLAUDE_TOOL_INPUT:-}" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+print(d.get('new_string', '') or d.get('content', ''))
+" 2>/dev/null || echo "")
+
+if echo "$CONTENT" | grep -qE "import org\.springframework|import jakarta"; then
+  echo "BLOCK: Spring/Jakarta import detected in core/ or infra/ — these packages must be framework-free."
+  echo "  Move the import to adapter/ or wire it through RateLimiterConfig.kt."
+  exit 2
+fi

--- a/.claude/skills/new-handler/SKILL.md
+++ b/.claude/skills/new-handler/SKILL.md
@@ -1,6 +1,6 @@
 # /new-handler — WebFlux Functional Endpoint Scaffold
 
-Scaffold a complete WebFlux Functional endpoint following the project's thin-handler convention. Every new endpoint requires exactly 4 pieces.
+Scaffold a complete WebFlux Functional endpoint following the project's thin-handler convention. Every new endpoint requires exactly 4 pieces, plus an exception class and a composed OpenAPI annotation.
 
 ---
 
@@ -29,7 +29,6 @@ data class <Name>Request(
 **Validation rules:**
 - Validation annotations go on the DTO, NOT in the handler
 - Use `@field:NotBlank`, `@field:Min`, `@field:Max` etc. as needed
-- Mark the parameter `@Valid` in the handler's `awaitBody<T>()` call if using Spring validation
 
 ---
 
@@ -53,24 +52,29 @@ Keep response DTOs flat — no nested objects unless the API contract requires i
 ```kotlin
 package com.iol.ratelimiter.adapter.api
 
-import com.iol.ratelimiter.core.port.RateLimiterPort
 import com.iol.ratelimiter.core.domain.RateLimitKey
+import com.iol.ratelimiter.core.domain.RateLimitResult
+import com.iol.ratelimiter.core.port.RateLimiterPort
+import org.springframework.validation.BeanPropertyBindingResult
+import org.springframework.validation.Validator
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
 import org.springframework.web.reactive.function.server.awaitBody
-import org.springframework.web.reactive.function.server.buildAndAwait
 import org.springframework.web.reactive.function.server.bodyValueAndAwait
 
-class <Name>Handler(private val rateLimiter: RateLimiterPort) {
-
+class <Name>Handler(
+    private val rateLimiter: RateLimiterPort,
+    private val validator: Validator,
+) {
     suspend fun <verb>(request: ServerRequest): ServerResponse {
         val body = request.awaitBody<<Name>Request>()
+        val errors = BeanPropertyBindingResult(body, "<name>Request")
+        validator.validate(body, errors)
+        if (errors.hasErrors()) return ServerResponse.badRequest().bodyValueAndAwait(errors.allErrors.map { it.defaultMessage })
+
         return when (val result = rateLimiter.tryConsume(RateLimitKey(body.key))) {
-            is RateLimitResult.Allowed -> ServerResponse.ok()
-                .bodyValueAndAwait(<Name>Response(allowed = true))
-            is RateLimitResult.Denied  -> ServerResponse.status(429)
-                .header("Retry-After", result.retryAfterSeconds.toString())
-                .bodyValueAndAwait(<Name>Response(allowed = false))
+            is RateLimitResult.Allowed -> ServerResponse.ok().bodyValueAndAwait(<Name>Response(allowed = true))
+            is RateLimitResult.Denied  -> throw <Name>ExceededException(result.retryAfterSeconds)
         }
     }
 }
@@ -80,9 +84,10 @@ class <Name>Handler(private val rateLimiter: RateLimiterPort) {
 - Handler functions are `suspend fun` — always
 - Use `awaitBody<T>()` to read the request body
 - Use `buildAndAwait()` or `bodyValueAndAwait(...)` to build responses
-- Handler maps HTTP status (`200`, `429`, etc.) from the domain result — nothing else
+- The `Denied` branch **throws** — never builds a 429 response directly in the handler
+- HTTP 429 mapping and `Retry-After` header live in the `@ExceptionHandler`, not here
 - Handler contains **NO business logic** — no if/else on domain fields, no computation
-- Handler does NOT validate — validation is on the DTO
+- Validation runs via `Validator`, error response is the only exception to the throw-on-deny rule
 
 ---
 
@@ -106,15 +111,109 @@ fun rateLimitRouter(
 
 ---
 
-## Wiring in `RateLimiterConfig.kt`
+## Exception + ExceptionHandler Pattern
 
-Register the new handler as a Spring bean:
+### `<Name>ExceededException.kt`
+
+```kotlin
+package com.iol.ratelimiter.adapter.api
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
+
+class <Name>ExceededException(
+    val retryAfterSeconds: Long,
+) : ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS)
+```
+
+### `<Name>ExceptionHandler.kt` (or add to the existing `RateLimitExceptionHandler`)
+
+```kotlin
+@ExceptionHandler(<Name>ExceededException::class)
+fun handle<Name>Exceeded(ex: <Name>ExceededException): ResponseEntity<<Name>Response> =
+    ResponseEntity
+        .status(ex.statusCode)
+        .header("Retry-After", ex.retryAfterSeconds.toString())
+        .body(<Name>Response(false))
+```
+
+**Why this pattern?**
+- The handler stays truly thin — it never decides the HTTP shape of an error response
+- `@RestControllerAdvice` centralises all error-to-HTTP mappings in one auditable file
+- New exception types are added to the advice class, not scattered across handler files
+
+---
+
+## OpenAPI — `@<Name>RouterOperations` Composed Annotation
+
+SpringDoc cannot introspect functional `coRouter` routes, so metadata must be declared explicitly.
+Use the composed-annotation pattern — one annotation per router, placed on the `@Bean` method.
+
+### `<Name>RouterOperations.kt`
+
+```kotlin
+package com.iol.ratelimiter.adapter.api
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import org.springdoc.core.annotations.RouterOperation
+import org.springdoc.core.annotations.RouterOperations
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.RequestMethod
+
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@RouterOperations(
+    RouterOperation(
+        path = "<path>",
+        method = [RequestMethod.<METHOD>],
+        beanClass = <Name>Handler::class,
+        beanMethod = "<verb>",
+        operation = Operation(
+            operationId = "<operationId>",
+            summary = "<summary>",
+            tags = ["<tag>"],
+            requestBody = RequestBody(
+                required = true,
+                content = [Content(schema = Schema(implementation = <Name>Request::class))],
+            ),
+            responses = [
+                ApiResponse(responseCode = "200", description = "...",
+                    content = [Content(schema = Schema(implementation = <Name>Response::class))]),
+                ApiResponse(responseCode = "429", description = "Rate limit exceeded — Retry-After header in seconds",
+                    content = [Content(schema = Schema(implementation = <Name>Response::class))]),
+                ApiResponse(responseCode = "400", description = "Missing or blank key field"),
+            ],
+        ),
+        consumes = [MediaType.APPLICATION_JSON_VALUE],
+        produces = [MediaType.APPLICATION_JSON_VALUE],
+    ),
+)
+annotation class <Name>RouterOperations
+```
+
+Place the annotation on the `@Bean` method in `RateLimiterConfig.kt`:
+```kotlin
+@Bean
+@<Name>RouterOperations
+fun rateLimitRouter(handler: RateLimitHandler, ...) = rateLimitRouter(handler, ...)
+```
+
+See `RateLimiterRouterOperations.kt` for the complete reference implementation.
+
+---
+
+## Wiring in `RateLimiterConfig.kt`
 
 ```kotlin
 @Bean
-fun <name>Handler(rateLimiter: RateLimiterPort) = <Name>Handler(rateLimiter)
+fun <name>Handler(rateLimiter: RateLimiterPort, validator: Validator) = <Name>Handler(rateLimiter, validator)
 
 @Bean
+@<Name>RouterOperations
 fun rateLimitRouter(
     rateLimitHandler: RateLimitHandler,
     <name>Handler: <Name>Handler,
@@ -127,8 +226,11 @@ fun rateLimitRouter(
 
 - [ ] `<Name>Request.kt` — validation on DTO fields
 - [ ] `<Name>Response.kt` — flat response DTO
-- [ ] `<Name>Handler.kt` — `suspend fun`, no business logic, maps HTTP status
+- [ ] `<Name>Handler.kt` — `suspend fun`, validates via `Validator`, throws on `Denied`
+- [ ] `<Name>ExceededException.kt` — extends `ResponseStatusException(TOO_MANY_REQUESTS)`
+- [ ] `@ExceptionHandler` entry in `RateLimitExceptionHandler` (or new advice class)
 - [ ] Router entry added to `RateLimiterRouter.kt`
+- [ ] `<Name>RouterOperations.kt` composed annotation + placed on `@Bean` in config
 - [ ] Bean registered in `RateLimiterConfig.kt`
 - [ ] Handler test added in `adapter/api/<Name>HandlerTest.kt` using `WebTestClient` + `@MockkBean`
 - [ ] `./gradlew build` passes

--- a/.claude/skills/spring-optimize/SKILL.md
+++ b/.claude/skills/spring-optimize/SKILL.md
@@ -1,0 +1,118 @@
+# /spring-optimize — Spring WebFlux Server Tuning
+
+Guide for tuning a reactive WebFlux rate-limiter for production. Covers Netty worker threads,
+Reactor scheduler discipline, JVM memory flags, and Actuator health probes.
+
+---
+
+## 1. Netty Worker Thread Count
+
+**File:** `src/main/resources/application.yaml`
+
+```yaml
+spring:
+  webflux:
+    netty:
+      worker-count: 4   # rule of thumb: 2× CPU cores
+```
+
+**Why:** Netty's event loop threads handle all I/O. The default is `max(2, cpu_cores)`.
+For a t2.micro (1 vCPU) the default of 2 is already correct. On larger instances set `2 × cpu_cores`.
+
+---
+
+## 2. Reactor Scheduler Discipline
+
+**Never block a Reactor thread** (event loop). The rate-limiter uses `AtomicReference` CAS — pure
+CPU arithmetic with no blocking I/O — so it is safe on the event loop today.
+
+If you ever introduce Redis / JDBC calls, wrap them:
+
+```kotlin
+// BAD: blocks event loop
+val result = redisClient.get(key)  // blocking call
+
+// GOOD: offload to boundedElastic
+withContext(Dispatchers.IO) {
+    redisClient.get(key)
+}
+```
+
+Reactor's `boundedElastic` scheduler is designed for blocking I/O offloading.
+
+---
+
+## 3. JVM Flags for Netty on Constrained Hosts
+
+Set via the `JAVA_OPTS` environment variable (in `compose.yaml` or EC2 launch script):
+
+```bash
+JAVA_OPTS="-XX:+UseZGC -Xmx256m -XX:MaxDirectMemorySize=128m -XX:+ExitOnOutOfMemoryError"
+```
+
+| Flag | Reason |
+|------|--------|
+| `-XX:+UseZGC` | Low-latency GC — sub-millisecond pauses ideal for reactive workloads |
+| `-Xmx256m` | Leaves room for Grafana LGTM stack on t2.micro (1 GB total) |
+| `-XX:MaxDirectMemorySize=128m` | Netty uses off-heap direct byte buffers for network I/O; without a cap the JVM default is `-Xmx`, which double-counts heap |
+| `-XX:+ExitOnOutOfMemoryError` | Crash-fast rather than limp — container orchestrator will restart |
+
+---
+
+## 4. Actuator Readiness Probe
+
+**File:** `src/main/resources/application.yaml`
+
+```yaml
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,metrics,info
+  endpoint:
+    health:
+      show-details: always
+```
+
+**Verification:**
+
+```bash
+./gradlew bootRun &
+curl http://localhost:8080/actuator/health
+# Expected: {"status":"UP","components":{...}}
+```
+
+AWS EC2 / Docker health check:
+```yaml
+# compose.yaml
+healthcheck:
+  test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health/readiness"]
+  interval: 10s
+  timeout: 5s
+  retries: 3
+```
+
+---
+
+## 5. OTel Sampling
+
+Set `probability: 1.0` (sample every request) in dev/staging; lower to `0.1` in production to
+reduce trace storage cost:
+
+```yaml
+spring:
+  otel:
+    tracing:
+      sampling:
+        probability: 1.0
+```
+
+---
+
+## Verification Checklist
+
+- [ ] `application.yaml` — `worker-count` set to `2 × cpu_cores`
+- [ ] No blocking calls on Reactor/Netty threads (grep for `.block()` in non-test code)
+- [ ] `JAVA_OPTS` set in `compose.yaml` / EC2 launch script
+- [ ] `curl localhost:8080/actuator/health` → `{"status":"UP"}`
+- [ ] `curl localhost:8080/actuator/health/readiness` → `{"status":"UP"}`

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,13 @@
     "context7": {
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp@latest"]
+    },
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- **`/new-handler` skill updated**: handler template now uses `throw RateLimitExceededException(result.retryAfterSeconds)` on `Denied` (matching the actual implementation), with added sections documenting the `@RestControllerAdvice` exception pattern and the `@<Name>RouterOperations` composed-annotation OpenAPI pattern
- **`guard-core-boundaries.sh`** (new PreToolUse hook): blocks Spring/Jakarta imports from being written into `core/` or `infra/` packages; reads incoming `new_string`/`content` from `CLAUDE_TOOL_INPUT` to catch violations before they land on disk
- **`detekt-on-save.sh`** upgraded: `./gradlew detektMain` → `./gradlew detekt` to cover test sources too
- **`/spring-optimize` skill** (new): guides Netty worker-count tuning, Reactor scheduler discipline, ZGC JVM flags, and Actuator readiness probe config
- **`coverage-diff-guardian` agent** (new): parses `jacocoTestReport.xml`, reports per-file line coverage, flags files below 90% (warning) and 80% (error)
- **GitHub MCP** added to `.mcp.json`: `GITHUB_TOKEN` sourced from shell environment — no secrets committed

## Test plan

- [ ] `./gradlew build` — still green (no app code changed)
- [ ] Invoke `/new-handler` and confirm output shows exception pattern + `@RouterOperations` section
- [ ] Verify `guard-core-boundaries.sh` exits 0 for an `adapter/` file path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update Claude automation skills and guardrails to enforce architectural boundaries, improve Spring WebFlux handler scaffolding, and add coverage and static analysis safeguards.

Enhancements:
- Extend the /new-handler WebFlux scaffold to include DTO validation via Validator, an exception + @RestControllerAdvice pattern for 429 responses, and a composed OpenAPI annotation for functional routes.
- Introduce a guard-core-boundaries shell hook to block Spring/Jakarta imports from being added to core and infra Kotlin packages based on incoming tool content.
- Add a new /spring-optimize skill documenting recommended Netty, Reactor, JVM, Actuator, and OTel configuration for production tuning.
- Broaden the detekt-on-save script to run detekt over both main and test sources.

Tests:
- Describe a coverage-diff-guardian agent that parses JaCoCo XML, reports per-file coverage for core/infra packages, and fails when files fall below configured thresholds.