### PR TITLE
enhancement: observability cleanup — remove redundant deps, add Actuator + OTel config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,17 +52,18 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-opentelemetry")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
-    implementation("io.micrometer:micrometer-tracing-bridge-brave")
     implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
     implementation("org.springdoc:springdoc-openapi-starter-webflux-ui:$springDocVersion")
+    // Optional defensive pattern: circuit breaker for the storage layer.
+    // Not wired in RateLimiterConfig — InMemoryBucketStore is in-process and cannot fail.
+    // Activate when replacing InMemoryBucketStore with a Redis backend.
     implementation("org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     developmentOnly("org.springframework.boot:spring-boot-docker-compose")
     runtimeOnly("io.micrometer:micrometer-registry-otlp")
-    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,6 +1,10 @@
 spring:
   application:
     name: sd-implementation-challenge
+  otel:
+    tracing:
+      sampling:
+        probability: 1.0
 
 springdoc:
   swagger-ui:
@@ -13,3 +17,13 @@ springdoc:
 rate-limiter:
   capacity: 10
   refill-rate-per-second: 5
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,metrics,info
+  endpoint:
+    health:
+      show-details: always
+


### PR DESCRIPTION
## Summary

- **Remove `micrometer-tracing-bridge-brave`**: transitive dep of `spring-boot-micrometer-tracing-brave` — explicit declaration adds nothing, removed to avoid version-pinning drift
- **Remove `micrometer-registry-prometheus`**: inert — the compose stack uses OTLP push (gRPC 4317), not Prometheus pull scraping; `micrometer-registry-otlp` is retained
- **Comment Resilience4j dep**: explains the intentional non-wiring — in-process store cannot fail; comment points to the Redis backend scenario where it activates
- **Actuator config in `application.yaml`**: expose `health`, `metrics`, `info`; `show-details: always` so `/actuator/health` returns component breakdown (useful for Docker health checks)
- **OTel sampling**: `probability: 1.0` under the existing `spring:` key — samples every request; lower to `0.1` for production trace cost control

## Test plan

- [ ] `./gradlew build` — green (dep removal compiled cleanly, no broken imports)
- [ ] `./gradlew bootRun` + `curl localhost:8080/actuator/health` → `{"status":"UP",...}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tidy observability configuration by simplifying metrics/tracing dependencies and enabling basic Actuator endpoints with explicit OpenTelemetry sampling settings.

New Features:
- Enable Spring Boot Actuator web exposure for health, metrics, and info endpoints, with detailed health information always shown.
- Configure OpenTelemetry tracing sampling probability to 1.0 in application configuration.

Enhancements:
- Clarify the purpose and intended activation conditions of the Resilience4j circuit breaker dependency via inline comments.

Build:
- Remove redundant Micrometer tracing bridge dependency that was already provided transitively.
- Remove unused Prometheus Micrometer registry in favor of OTLP-based metrics export.