### PR TITLE
feature: Docker + AWS EC2 deployment — multi-stage Dockerfile, compose update, deployment guide

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Gradle build outputs and caches — rebuilt inside the builder stage
+.gradle/
+build/
+
+# Version control — not needed in build context
+.git/
+.gitignore
+
+# Claude Code — IDE tooling, not app code
+.claude/
+
+# Documentation and diagrams — not needed for compilation
+*.md
+diagrams/
+docs/
+rate-limiter/
+
+# Local observability data
+.loki/
+
+# PlantUML source files
+*.puml
+
+# Docker files themselves — avoids circular inclusion issues
+Dockerfile
+.dockerignore
+docker-compose*.yml
+compose.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Stage 1: build — full JDK required for Gradle compilation
+FROM eclipse-temurin:24-jdk AS builder
+WORKDIR /build
+COPY . .
+RUN ./gradlew bootJar --no-daemon -x test
+
+# Stage 2: runtime — JRE only (no compiler, no Gradle, ~200 MB vs ~500 MB)
+FROM eclipse-temurin:24-jre AS runtime
+WORKDIR /app
+COPY --from=builder /build/build/libs/*.jar app.jar
+
+# ZGC: sub-millisecond GC pauses — essential for reactive/low-latency workloads
+# Xmx256m: leaves ~700 MB for the Grafana LGTM stack on a t2.micro (1 GB total)
+# MaxDirectMemorySize: Netty uses off-heap direct buffers for network I/O;
+#   without an explicit cap the JVM defaults to Xmx, effectively double-counting memory
+# ExitOnOutOfMemoryError: crash-fast rather than limping — orchestrators restart cleanly
+ENV JAVA_OPTS="-XX:+UseZGC -Xmx256m -XX:MaxDirectMemorySize=128m -XX:+ExitOnOutOfMemoryError"
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]
+EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ com.iol.ratelimiter/
 
 ---
 
+## Docker
+
+Start the app + full observability stack with one command:
+
+```bash
+docker compose up
+```
+
+| Service | URL |
+|---------|-----|
+| App | http://localhost:8080 |
+| Grafana | http://localhost:3000 |
+| Prometheus | http://localhost:9090 |
+
+See [`docs/deployment.md`](docs/deployment.md) for AWS EC2 free-tier deployment instructions.
+
+---
+
 ## Quality Gates
 
 All gates are enforced by `./gradlew build` via `tasks.check`:

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,5 +3,24 @@ services:
     image: 'grafana/otel-lgtm:latest'
     ports:
       - '3000:3000'
+      - '9090:9090'
       - '4317'
       - '4318'
+    networks:
+      - observability
+
+  app:
+    build: .
+    ports:
+      - '8080:8080'
+    environment:
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://grafana-lgtm:4317
+      OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+      OTEL_SERVICE_NAME: rate-limiter
+    depends_on:
+      - grafana-lgtm
+    networks:
+      - observability
+
+networks:
+  observability:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,163 @@
+# Deployment Guide
+
+## Overview
+
+The app ships with a `compose.yaml` that starts the rate-limiter alongside a self-hosted
+Grafana LGTM stack. OTLP (gRPC) is used for metrics and traces — no Prometheus scrape config needed.
+
+---
+
+## Local (Docker Compose)
+
+**Prerequisites:** Docker with the Compose plugin installed.
+
+```bash
+# Start app + Grafana LGTM stack
+docker compose up
+
+# Detached
+docker compose up -d
+
+# Rebuild app image after code changes
+docker compose up --build
+```
+
+| Service | URL |
+|---------|-----|
+| App | http://localhost:8080 |
+| Grafana | http://localhost:3000 |
+| Prometheus-compatible endpoint | http://localhost:9090 |
+
+Smoke test:
+```bash
+curl -X POST http://localhost:8080/api/rate-limit/check \
+  -H 'Content-Type: application/json' \
+  -d '{"key":"user-1"}'
+# → 200 {"allowed":true}
+```
+
+Health check:
+```bash
+curl http://localhost:8080/actuator/health
+# → {"status":"UP","components":{...}}
+```
+
+---
+
+## AWS EC2 Free Tier (24/7 hosting)
+
+AWS EC2 t2.micro is **750 hours/month free for 12 months** — enough for continuous operation.
+
+### 1. Launch an EC2 instance
+
+- AMI: **Amazon Linux 2023** (free tier eligible)
+- Instance type: **t2.micro** (1 vCPU, 1 GB RAM)
+- Storage: 8 GB gp2 (default)
+- Key pair: create or select an existing `.pem` key
+
+### 2. Security group rules
+
+| Type | Protocol | Port | Source |
+|------|----------|------|--------|
+| SSH | TCP | 22 | Your IP (e.g. `x.x.x.x/32`) |
+| Custom TCP | TCP | 8080 | `0.0.0.0/0` (API) |
+| Custom TCP | TCP | 3000 | `0.0.0.0/0` (Grafana) |
+
+Restrict port 3000 to your IP in production — Grafana has no auth by default.
+
+### 3. Install Docker on Amazon Linux 2023
+
+```bash
+# Connect to the instance
+ssh -i your-key.pem ec2-user@<public-ip>
+
+# Install Docker
+sudo dnf install -y docker
+sudo systemctl start docker
+sudo systemctl enable docker
+sudo usermod -aG docker ec2-user   # allows running docker without sudo
+# Re-login for group change to take effect
+
+# Install Compose plugin
+sudo mkdir -p /usr/local/lib/docker/cli-plugins
+sudo curl -SL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64 \
+  -o /usr/local/lib/docker/cli-plugins/docker-compose
+sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+```
+
+### 4. Clone and run
+
+```bash
+git clone https://github.com/tompais/iol-system-design-implementation-challenge.git
+cd iol-system-design-implementation-challenge/sd-implementation-challenge
+
+# First run builds the app image (~3–5 min on t2.micro)
+docker compose up -d
+
+# Follow logs
+docker compose logs -f app
+```
+
+### 5. Verify
+
+```bash
+# From EC2 or your local machine (replace <public-ip>)
+curl -X POST http://<public-ip>:8080/api/rate-limit/check \
+  -H 'Content-Type: application/json' \
+  -d '{"key":"smoke-test"}'
+# → 200 {"allowed":true}
+```
+
+Grafana: open `http://<public-ip>:3000` in a browser (default credentials: admin / admin).
+
+---
+
+## JVM Sizing Rationale (t2.micro, 1 GB total)
+
+The `Dockerfile` sets these JVM flags via `JAVA_OPTS`:
+
+| Flag | Value | Reason |
+|------|-------|--------|
+| `-XX:+UseZGC` | — | Sub-millisecond GC pauses — ideal for reactive workloads |
+| `-Xmx256m` | 256 MB | App heap ceiling; leaves ~700 MB for LGTM stack |
+| `-XX:MaxDirectMemorySize` | 128 MB | Netty direct buffer cap — off-heap, not counted in `-Xmx` |
+| `-XX:+ExitOnOutOfMemoryError` | — | Crash-fast; Docker restarts the container |
+
+Typical memory footprint:
+- App JVM (heap + direct): ~256 MB + 128 MB = ~384 MB
+- Grafana LGTM container: ~400–450 MB
+- OS + Docker overhead: ~100 MB
+- **Total: ~884 MB — fits within 1 GB**
+
+---
+
+## Grafana Dashboards
+
+Import pre-built dashboards from grafana.com after the stack starts:
+
+| Dashboard | ID |
+|-----------|-----|
+| Spring Boot Statistics | 12685 |
+| JVM (Micrometer) | 4701 |
+
+In Grafana: **Dashboards → Import → paste ID → Load**.
+
+---
+
+## Updating the App
+
+```bash
+git pull
+docker compose up --build -d
+```
+
+The `--build` flag rebuilds the app image; `grafana-lgtm` is not rebuilt (uses the existing image).
+
+---
+
+## Stopping
+
+```bash
+docker compose down          # stop containers, keep volumes (Grafana data retained)
+docker compose down -v       # stop + delete volumes (Grafana data wiped)
+```


### PR DESCRIPTION
## Summary

- **`Dockerfile`** (new): two-stage build — `eclipse-temurin:24-jdk` builder compiles via `bootJar`, `eclipse-temurin:24-jre` runtime keeps the image lean (~200 MB vs ~500 MB); JVM flags tuned for reactive workloads on t2.micro (`ZGC`, `Xmx256m`, `MaxDirectMemorySize=128m`, `ExitOnOutOfMemoryError`)
- **`.dockerignore`** (new): excludes `.gradle/`, `build/`, `.git/`, `.claude/`, `*.md`, `diagrams/`, `docs/`, `.loki/`, `*.puml` — build context is `src/` + config files only
- **`compose.yaml`** updated: adds `app` service (builds from `Dockerfile`) and an `observability` network; app pushes OTLP metrics+traces to `grafana-lgtm:4317` inside the Docker network; Prometheus-compatible endpoint exposed on `:9090`
- **`docs/deployment.md`** (new): step-by-step AWS EC2 t2.micro free-tier setup (Amazon Linux 2023 + Docker + Compose plugin), security group rules, JVM sizing rationale, Grafana dashboard import IDs
- **`README.md`**: new Docker section with one-command startup table and link to deployment guide

## Depends on

PR #13 (observability cleanup) — clean `application.yaml` with OTLP defaults (already merged)

## Test plan

- [ ] `docker compose up` starts cleanly (app + grafana-lgtm containers)
- [ ] `curl -X POST localhost:8080/api/rate-limit/check -H 'Content-Type: application/json' -d '{"key":"smoke"}' ` → 200 `{"allowed":true}`
- [ ] `curl localhost:8080/actuator/health` → `{"status":"UP"}`
- [ ] Grafana at http://localhost:3000 shows JVM metrics after importing dashboard ID 4701

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add Docker-based deployment with a multi-stage image and local observability stack, plus documentation for local and AWS EC2 hosting.

New Features:
- Introduce an application service in Docker Compose wired to the Grafana LGTM stack for metrics and traces.
- Provide a local one-command Docker setup for running the app with full observability.

Enhancements:
- Configure an observability Docker network and expose a Prometheus-compatible endpoint from the LGTM stack.

Build:
- Add a multi-stage Dockerfile using a slim JRE runtime with JVM settings tuned for low-memory environments.
- Add a .dockerignore to reduce Docker build context and image size.

Documentation:
- Add a detailed deployment guide covering local Docker Compose usage and AWS EC2 free-tier setup.
- Update the README with Docker usage instructions and links to the deployment guide.