### PR TITLE
enhancement: replace PlantUML component diagram with Mermaid (GitHub-native)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,15 @@ Hexagonal (ports-and-adapters) in a single Gradle module, 4 logical layers:
 
 ```
 com.iol.ratelimiter/
-  core/domain/     ← pure domain: RateLimitKey, BucketState, RateLimitResult, TokenBucketConfig
+  core/domain/     ← pure domain: RateLimitKey, BucketState, RateLimitDeniedException, TokenBucketConfig
   core/port/       ← interfaces: Clock, BucketStore, RateLimiterPort
   infra/           ← implementations: SystemClock, InMemoryBucketStore, TokenBucketRateLimiter
   adapter/api/     ← WebFlux Functional router (coRouter) + thin handler + DTOs + exception handler
   RateLimiterConfig.kt  ← @Configuration wiring all beans (zero @Component in infra/adapter)
   OpenApiConfig.kt      ← SpringDoc OpenAPI metadata
 ```
+
+See [`diagrams/component.mmd`](diagrams/component.mmd) for the full component diagram (renders natively on GitHub).
 
 **Algorithm:** Token Bucket with lazy refill. State stored as `milliTokens` (Long) for exact integer CAS — 1 token = 1000 milliTokens. Refill computed on each `tryConsume()` from elapsed time; no background threads.
 
@@ -118,7 +120,7 @@ Traces include `traceId` and `spanId` in every log line via the Log4j2 pattern (
 
 | Layer | Test class | Type |
 |---|---|---|
-| Domain types | `RateLimitKeyTest`, `RateLimitResultTest` | Pure unit |
+| Domain types | `RateLimitKeyTest` | Pure unit |
 | Algorithm | `TokenBucketRateLimiterTest` | Unit (injectable Clock) |
 | Store isolation | `InMemoryBucketStoreTest` | Unit |
 | Concurrency | `TokenBucketConcurrencyTest` | Race test (`@RepeatedTest(10)`, 100 threads) |

--- a/diagrams/component.mmd
+++ b/diagrams/component.mmd
@@ -1,0 +1,56 @@
+flowchart TB
+    subgraph adapter["adapter/api — WebFlux Functional"]
+        Router["RateLimiterRouter\ncoRouter { POST }"]
+        Handler["RateLimitHandler\nsuspend fun check()"]
+        BodyValidator["BodyValidator\nvalidate(body)"]
+        ExHandler["RateLimitExceptionHandler\n@RestControllerAdvice"]
+        DTOs["RateLimitRequest\nRateLimitResponse"]
+    end
+
+    subgraph ports["core/port — Interfaces"]
+        Port(["RateLimiterPort\ntryConsume(key): Unit"])
+        StorePort(["BucketStore\ngetOrCreate(key, init)"])
+        ClockPort(["Clock\nnowMillis(): Long"])
+    end
+
+    subgraph domain["core/domain — Pure Kotlin"]
+        Key["RateLimitKey\n@JvmInline value class"]
+        State["BucketState\nmilliTokens, lastRefillAt"]
+        Config["TokenBucketConfig\ncapacity, refillRatePerSecond"]
+        DeniedException["RateLimitDeniedException\nretryAfterSeconds: Long"]
+    end
+
+    subgraph infra["infra — Implementations"]
+        Limiter["TokenBucketRateLimiter\nCAS loop + lazy refill"]
+        Store["InMemoryBucketStore\nConcurrentHashMap"]
+        Clock["SystemClock\nSystem.currentTimeMillis()"]
+    end
+
+    Cfg["RateLimiterConfig\n@Configuration"]
+
+    Router --> Handler
+    Handler --> BodyValidator
+    Handler --> Port
+    Handler -.->|throws| DeniedException
+    ExHandler -.->|catches| DeniedException
+    Handler --> DTOs
+    ExHandler --> DTOs
+
+    Port -.->|implements| Limiter
+    StorePort -.->|implements| Store
+    ClockPort -.->|implements| Clock
+
+    Limiter --> StorePort
+    Limiter --> ClockPort
+    Limiter --> State
+    Limiter --> Config
+    Limiter -.->|throws| DeniedException
+
+    Handler --> Key
+
+    Cfg -.->|@Bean| Limiter
+    Cfg -.->|@Bean| Store
+    Cfg -.->|@Bean| Clock
+    Cfg -.->|@Bean| Handler
+    Cfg -.->|@Bean| BodyValidator
+    Cfg -.->|@Bean| Router

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,8 @@ The rate limiter follows **Hexagonal Architecture** (ports and adapters), organi
 ├─────────────────────────────────────────────────┤
 │  core/domain        Pure Kotlin types             │
 │  (business)         RateLimitKey, BucketState,    │
-│                     RateLimitResult, Config        │
+│                     RateLimitDeniedException,      │
+│                     TokenBucketConfig              │
 ├─────────────────────────────────────────────────┤
 │  infra/             Implementations               │
 │  (tech detail)      SystemClock, InMemoryStore,   │
@@ -22,7 +23,7 @@ The rate limiter follows **Hexagonal Architecture** (ports and adapters), organi
 └─────────────────────────────────────────────────┘
 ```
 
-See [`diagrams/component.puml`](../diagrams/component.puml) for the full PlantUML component diagram.
+See [`diagrams/component.mmd`](../diagrams/component.mmd) for the Mermaid component diagram (renders natively on GitHub). The PlantUML sequence diagram is at [`diagrams/sequence-check.puml`](../diagrams/sequence-check.puml).
 
 ---
 
@@ -54,7 +55,7 @@ The HTTP layer uses **WebFlux Functional style** (not `@RestController`). This m
 
 - **Router** (`RateLimiterRouter.kt`): declares routes only — `coRouter { POST("/path", handler::fn) }`
 - **Handler** (`RateLimitHandler.kt`): validates request body, delegates to `RateLimiterPort`, throws on denial
-- **Exception Handler** (`RateLimitExceptionHandler.kt`): `@RestControllerAdvice` that maps `RateLimitExceededException` to 429 + `Retry-After` — keeps the handler free of HTTP status decisions
+- **Exception Handler** (`RateLimitExceptionHandler.kt`): `@RestControllerAdvice` that maps `RateLimitDeniedException` → 429 + `Retry-After` and `BadRequestException` → 400 — keeps the handler free of HTTP status decisions
 - **DTOs** (`RateLimitRequest`, `RateLimitResponse`): data classes at the HTTP boundary only
 
 The router is a `RouterFunction` bean — it can be tested with `WebTestClient.bindToRouterFunction()` (standalone, no server) or via `@SpringBootTest(RANDOM_PORT)` for full context including the exception handler.


### PR DESCRIPTION
## Summary
- Adds `diagrams/component.mmd` — Mermaid `flowchart TB` with subgraphs for each hexagonal layer
- Reflects post-PR-B architecture: `RateLimitDeniedException`, `BodyValidator`, no `RateLimitResult`
- Updates `docs/architecture.md` and `README.md` to link the new diagram
- Mermaid renders natively in GitHub markdown — no Graphviz, no plugin, no Smetana renderer needed

## Test plan
- [ ] Open PR diff on GitHub — `component.mmd` renders as a diagram in the file preview
- [ ] `./gradlew build` green (no Kotlin changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace the PlantUML component diagram with a GitHub-native Mermaid diagram and align architecture docs with the current domain model and exception handling.

Enhancements:
- Add a Mermaid-based component diagram that mirrors the hexagonal architecture and replaces the previous PlantUML component diagram file.

Documentation:
- Update architecture documentation to reference the new Mermaid component diagram and reflect the current domain types and exception mapping.
- Update README to describe the revised domain model, link to the Mermaid diagram, and adjust the documented test matrix.