### PR TITLE
feature: auto-request Copilot review on new PRs to master

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,23 @@
+name: Request Copilot Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+    branches: [master]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  request-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add Copilot as reviewer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr edit "$PR_NUMBER" \
+            --repo "$REPO" \
+            --add-reviewer "github-copilot[bot]"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/copilot-review.yml` — triggers on `pull_request.opened` and `ready_for_review` targeting master
- Adds `github-copilot[bot]` as a reviewer automatically
- Uses `env:` vars for all GitHub context values (safe pattern per GH Actions security guide)

## Test plan
- [ ] Open a new PR against master → Copilot bot appears as requested reviewer
- [ ] Workflow run completes without `gh` CLI errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a GitHub Actions workflow to automatically request a Copilot review on new pull requests targeting master.

New Features:
- Automatically request a review from github-copilot[bot] when pull requests to the master branch are opened or marked ready for review.

CI:
- Introduce a GitHub Actions workflow that uses the GitHub CLI to add github-copilot[bot] as a reviewer on qualifying pull requests.