### PR TITLE
feature: k6 demo script with 5 labelled scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,22 @@ See [`docs/testing.md`](docs/testing.md) for the full TDD approach and test pyra
 
 ---
 
+## Live Demo
+
+A [k6](https://k6.io) script exercises the rate limiter end-to-end: single request, bucket exhaustion, validation errors (missing key, blank key), and 100-VU concurrency burst.
+
+```bash
+# 1. Start the app
+docker compose up
+
+# 2. Run the demo (requires k6)
+k6 run demo/rate-limiter-demo.js
+```
+
+See [`demo/README.md`](demo/README.md) for details on all 5 scenarios and expected output.
+
+---
+
 ## Design Document
 
 [`rate-limiter/DESIGN.md`](rate-limiter/DESIGN.md) — required submission artifact. Covers algorithm choice, thread-safety model, key design decisions, trade-offs, and AI usage.

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,61 @@
+# Live Demo — k6 Load Test
+
+A [k6](https://k6.io) script that exercises the rate limiter end-to-end with five labelled
+scenarios. Each scenario has a threshold — the script exits non-zero if any check fails.
+
+## Prerequisites
+
+1. App running on `http://localhost:8080` (either via Docker or Gradle):
+   ```bash
+   docker compose up        # starts app + Grafana LGTM stack
+   # or
+   ./gradlew bootRun
+   ```
+
+2. k6 installed:
+   ```bash
+   brew install k6          # macOS
+   # or see https://k6.io/docs/getting-started/installation/
+   ```
+
+## Run
+
+```bash
+k6 run demo/rate-limiter-demo.js
+```
+
+Override the base URL if needed:
+
+```bash
+BASE_URL=http://my-server:8080 k6 run demo/rate-limiter-demo.js
+```
+
+## Scenarios
+
+| Scenario | What it tests | Expected |
+|----------|--------------|----------|
+| `single_allowed` | Fresh UUID key | 200 `{"allowed":true}` |
+| `bucket_exhaustion` | 10 requests same key → 11th | first 10: 200 · 11th: 429 + `Retry-After` |
+| `validation_missing_key` | POST `{}` | 400 |
+| `validation_blank_key` | POST `{"key":""}` | 400 |
+| `concurrency` | 100 VUs same key simultaneously | 10 allowed + 90 denied |
+
+## Expected Output
+
+```
+✓ single allowed → 200
+✓ single allowed → allowed=true
+✓ request 1 allowed → 200
+...
+✓ exhausted bucket → 429
+✓ exhausted bucket → allowed=false
+✓ exhausted bucket → Retry-After present
+✓ missing key → 400
+✓ blank key → 400
+✓ burst allowed → allowed=true (×10)
+✓ burst denied → 429 (×90)
+
+Concurrency burst: 10 allowed / 90 denied (capacity=10)
+```
+
+All checks at `rate==1` → exit code 0.

--- a/demo/rate-limiter-demo.js
+++ b/demo/rate-limiter-demo.js
@@ -1,0 +1,152 @@
+/**
+ * k6 demo script for the Token Bucket rate limiter.
+ *
+ * Prerequisites: app running on http://localhost:8080
+ *   docker compose up   (or ./gradlew bootRun)
+ *
+ * Run:
+ *   k6 run demo/rate-limiter-demo.js
+ *
+ * Exits 0 if all checks pass; non-zero on any failure.
+ *
+ * Default config: capacity=10, refillRatePerSecond=5 (see application.yaml)
+ */
+import http from "k6/http";
+import { check, sleep } from "k6";
+import { uuidv4 } from "https://jslib.k6.io/k6-utils/1.4.0/index.js";
+
+const BASE_URL = __ENV.BASE_URL || "http://localhost:8080";
+const ENDPOINT = `${BASE_URL}/api/rate-limit/check`;
+const HEADERS = { "Content-Type": "application/json" };
+const CAPACITY = 10;
+
+export const options = {
+  scenarios: {
+    single_allowed: {
+      executor: "shared-iterations",
+      vus: 1,
+      iterations: 1,
+      exec: "singleAllowed",
+      startTime: "0s",
+    },
+    bucket_exhaustion: {
+      executor: "shared-iterations",
+      vus: 1,
+      iterations: 1,
+      exec: "bucketExhaustion",
+      startTime: "1s",
+    },
+    validation_missing_key: {
+      executor: "shared-iterations",
+      vus: 1,
+      iterations: 1,
+      exec: "validationMissingKey",
+      startTime: "3s",
+    },
+    validation_blank_key: {
+      executor: "shared-iterations",
+      vus: 1,
+      iterations: 1,
+      exec: "validationBlankKey",
+      startTime: "4s",
+    },
+    concurrency: {
+      executor: "shared-iterations",
+      vus: 100,
+      iterations: 100,
+      exec: "concurrencyBurst",
+      startTime: "5s",
+      maxDuration: "15s",
+    },
+  },
+  thresholds: {
+    // All named checks must pass 100% of the time
+    "checks{scenario:single_allowed}": ["rate==1"],
+    "checks{scenario:bucket_exhaustion}": ["rate==1"],
+    "checks{scenario:validation_missing_key}": ["rate==1"],
+    "checks{scenario:validation_blank_key}": ["rate==1"],
+    "checks{scenario:concurrency}": ["rate==1"],
+  },
+};
+
+/** Scenario 1: Fresh UUID key — must be allowed (200 + allowed=true) */
+export function singleAllowed() {
+  const key = uuidv4();
+  const res = http.post(ENDPOINT, JSON.stringify({ key }), { headers: HEADERS });
+  check(res, {
+    "single allowed → 200": (r) => r.status === 200,
+    "single allowed → allowed=true": (r) => JSON.parse(r.body).allowed === true,
+  });
+}
+
+/**
+ * Scenario 2: Exhaust a bucket.
+ * First CAPACITY requests on the same key must be allowed; the (CAPACITY+1)th must be denied.
+ */
+export function bucketExhaustion() {
+  const key = `exhaust-${uuidv4()}`;
+
+  for (let i = 0; i < CAPACITY; i++) {
+    const res = http.post(ENDPOINT, JSON.stringify({ key }), { headers: HEADERS });
+    check(res, {
+      [`request ${i + 1} allowed → 200`]: (r) => r.status === 200,
+    });
+  }
+
+  // CAPACITY+1 must be denied
+  const denied = http.post(ENDPOINT, JSON.stringify({ key }), { headers: HEADERS });
+  check(denied, {
+    "exhausted bucket → 429": (r) => r.status === 429,
+    "exhausted bucket → allowed=false": (r) => JSON.parse(r.body).allowed === false,
+    "exhausted bucket → Retry-After present": (r) => r.headers["Retry-After"] !== undefined,
+  });
+
+  sleep(1);
+}
+
+/** Scenario 3: Missing key field — must return 400 */
+export function validationMissingKey() {
+  const res = http.post(ENDPOINT, JSON.stringify({}), { headers: HEADERS });
+  check(res, {
+    "missing key → 400": (r) => r.status === 400,
+  });
+}
+
+/** Scenario 4: Blank key value — must return 400 */
+export function validationBlankKey() {
+  const res = http.post(ENDPOINT, JSON.stringify({ key: "" }), { headers: HEADERS });
+  check(res, {
+    "blank key → 400": (r) => r.status === 400,
+  });
+}
+
+/**
+ * Scenario 5: Concurrency burst.
+ * 100 VUs all hit the same key simultaneously. Bucket capacity = 10,
+ * so exactly 10 must return 200 and 90 must return 429.
+ */
+const CONCURRENCY_KEY = `burst-${uuidv4()}`;
+let allowed = 0;
+let denied = 0;
+
+export function concurrencyBurst() {
+  const res = http.post(ENDPOINT, JSON.stringify({ key: CONCURRENCY_KEY }), { headers: HEADERS });
+
+  if (res.status === 200) {
+    allowed++;
+    check(res, {
+      "burst allowed → allowed=true": (r) => JSON.parse(r.body).allowed === true,
+    });
+  } else {
+    denied++;
+    check(res, {
+      "burst denied → 429": (r) => r.status === 429,
+      "burst denied → allowed=false": (r) => JSON.parse(r.body).allowed === false,
+    });
+  }
+}
+
+export function handleSummary(data) {
+  console.log(`\nConcurrency burst: ${allowed} allowed / ${denied} denied (capacity=${CAPACITY})`);
+  return {};
+}


### PR DESCRIPTION
## Summary
- Adds `demo/rate-limiter-demo.js` — k6 script with 5 scenarios (single allowed, bucket exhaustion, validation ×2, 100-VU concurrency burst)
- Thresholds enforce `rate==1` on all check groups — exits non-zero on any failure
- Adds `demo/README.md` with prerequisites, run command, scenario table, expected output
- Updates `README.md` with a "Live Demo" section and one-liner to run it

## Test plan
- [ ] `k6 run demo/rate-limiter-demo.js` against a running app exits 0
- [ ] Bucket exhaustion scenario shows exactly 10 × 200 then 1 × 429
- [ ] Concurrency scenario summary shows `10 allowed / 90 denied (capacity=10)`
- [ ] `./gradlew build` green (no source changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a k6-based live demo that exercises the token-bucket rate limiter end-to-end via five labelled load-test scenarios and document how to run it from the project.

New Features:
- Introduce a k6 demo script with five labelled scenarios to validate rate limiter behaviour under normal, exhaustion, validation error, and high-concurrency conditions.

Enhancements:
- Document the demo scenarios, prerequisites, and expected outcomes in a new demo README and link them from the main README via a Live Demo section.